### PR TITLE
Grep

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
     compile "org.antlr:antlr4-runtime:4.7.1"
     antlr "org.antlr:antlr4:4.7.1"
+    compile "com.xenomachina:kotlin-argparser:2.0.+"
 }
 
 mainClassName = 'ru.iisuslik.cli.MainKt'

--- a/cli/src/main/antlr/Cli.g4
+++ b/cli/src/main/antlr/Cli.g4
@@ -33,11 +33,11 @@ arg returns [String value]
     ;
 
 word
-    :   (LETTER | DIGIT | '.' | '-')+
+    :   (LETTER | DIGIT | '.' | '-' | '/')+
     ;
 
 string
-    : (LETTER | DIGIT | '.' | '-' | ' ' | '!' | '\t' | '|')+
+    : (LETTER | DIGIT | '.' | '-' | ' ' | '!' | '\t' | '|' | '\\' | '(' | ')' | '*' | '[' | ']' | '+' | '^' | '$')+
     ;
 
 DIGIT

--- a/cli/src/main/kotlin/ru/iisuslik/cli/FilesController.kt
+++ b/cli/src/main/kotlin/ru/iisuslik/cli/FilesController.kt
@@ -107,12 +107,12 @@ fun executeCommand(name: String, args: List<String>, input: String): String {
 fun grepInput(input: String, regex: Regex, linesCount: Int): String {
     val stringBuilder = StringBuilder()
     var curCount = 0
-    for (line in input.split('\n')) {
+    for (line in input.split(System.lineSeparator())) {
         if (regex.containsMatchIn(line)) {
-            stringBuilder.append(line + '\n')
+            stringBuilder.append(line + System.lineSeparator())
             curCount = linesCount
         } else if (curCount > 0) {
-            stringBuilder.append(line + '\n')
+            stringBuilder.append(line + System.lineSeparator())
             curCount--
         }
     }
@@ -124,8 +124,7 @@ fun grepFiles(fileNames: List<String>, regex: Regex, linesCount: Int): String {
     for (fileName in fileNames) {
         val file = File(fileName)
         if (!file.exists()) {
-            println("File \"$fileName\" doesn't exists")
-            continue
+            throw ErrorInCommandException("File \"$fileName\" doesn't exists")
         }
         val fileText = file.readText()
         val grepResult = grepInput(fileText, regex, linesCount)

--- a/cli/src/main/kotlin/ru/iisuslik/cli/FilesController.kt
+++ b/cli/src/main/kotlin/ru/iisuslik/cli/FilesController.kt
@@ -59,7 +59,7 @@ fun wcFiles(fileNames: List<String>): String {
     return stringBuilder.toString()
 }
 
-class CommandNotFoundException(message: String): Exception(message)
+class CommandNotFoundException(message: String) : Exception(message)
 
 // Executes external command
 fun executeCommand(name: String, args: List<String>, input: String): String {
@@ -73,4 +73,34 @@ fun executeCommand(name: String, args: List<String>, input: String): String {
     process.waitFor()
     print(process.errorStream.bufferedReader().readLine() ?: "")
     return process.inputStream.bufferedReader().readText()
+}
+
+fun grepInput(input: String, regex: Regex, linesCount: Int): String {
+    val stringBuilder = StringBuilder()
+    var curCount = 0
+    for (line in input.split('\n')) {
+        if (regex.containsMatchIn(line)) {
+            stringBuilder.append(line + '\n')
+            curCount = linesCount
+        } else if (curCount > 0) {
+            stringBuilder.append(line + '\n')
+            curCount--
+        }
+    }
+    return stringBuilder.toString()
+}
+
+fun grepFiles(fileNames: List<String>, regex: Regex, linesCount: Int): String {
+    val stringBuilder = StringBuilder()
+    for (fileName in fileNames) {
+        val file = File(fileName)
+        if (!file.exists()) {
+            println("File \"$fileName\" doesn't exists")
+            continue
+        }
+        val fileText = file.readText()
+        val grepResult = grepInput(fileText, regex, linesCount)
+        stringBuilder.append(grepResult)
+    }
+    return stringBuilder.toString()
 }

--- a/cli/src/main/kotlin/ru/iisuslik/cli/StatementParser.kt
+++ b/cli/src/main/kotlin/ru/iisuslik/cli/StatementParser.kt
@@ -94,6 +94,7 @@ class StatementParser(val varsContainer: VarsContainer) {
                 "echo" -> Echo(args)
                 "wc" -> Wc(args)
                 "cat" -> Cat(args)
+                "grep" -> Grep(args)
                 // Real bash doesn't care too if we pass any args to pwd or exit
                 "pwd" -> Pwd
                 "exit" -> Exit

--- a/cli/src/test/kotlin/ru/iisuslik/cli/ExecutorTest.kt
+++ b/cli/src/test/kotlin/ru/iisuslik/cli/ExecutorTest.kt
@@ -151,8 +151,37 @@ class ExecutorTest {
         assertEquals(
             "kek find me lol\nkeeeeek\n", executor.runCommands(
                 listOf(
-                    Grep(listOf("-w", "-n", "1", "find", getRealFileName("file4")))
+                    Grep(listOf("-w", "-A", "1", "find", getRealFileName("file4")))
                 )
+            )
+        )
+    }
+
+    @Test(expected = ErrorInCommandException::class)
+    fun grepWrongA() {
+        executor.runCommands(
+            listOf(
+                Grep(listOf("-A", "-10", "find", getRealFileName("file4")))
+            )
+        )
+
+    }
+
+    @Test(expected = ErrorInCommandException::class)
+    fun grepWrongKey() {
+        executor.runCommands(
+            listOf(
+                Grep(listOf("-q", "find", getRealFileName("file4")))
+            )
+        )
+
+    }
+
+    @Test(expected = ErrorInCommandException::class)
+    fun grepWrongEmptyA() {
+        executor.runCommands(
+            listOf(
+                Grep(listOf("-A", "find", getRealFileName("file4")))
             )
         )
     }

--- a/cli/src/test/kotlin/ru/iisuslik/cli/ExecutorTest.kt
+++ b/cli/src/test/kotlin/ru/iisuslik/cli/ExecutorTest.kt
@@ -94,7 +94,7 @@ class ExecutorTest {
     @Test
     fun grepSimple() {
         assertEquals(
-            "2\n",
+            "2${System.lineSeparator()}",
             executor.runCommands(listOf(Grep(listOf("2", getRealFileName("file4")))))
         )
     }
@@ -102,7 +102,7 @@ class ExecutorTest {
     @Test
     fun grepInput() {
         assertEquals(
-            "1\n", executor.runCommands(
+            "1${System.lineSeparator()}", executor.runCommands(
                 listOf(
                     Echo(listOf("1")),
                     Grep(listOf("1"))
@@ -114,7 +114,7 @@ class ExecutorTest {
     @Test
     fun grepInputIgnore() {
         assertEquals(
-            "2\n", executor.runCommands(
+            "2${System.lineSeparator()}", executor.runCommands(
                 listOf(
                     Echo(listOf("1")),
                     Grep(listOf("2", getRealFileName("file4")))
@@ -126,7 +126,7 @@ class ExecutorTest {
     @Test
     fun grepIgnoreCase() {
         assertEquals(
-            "A\n", executor.runCommands(
+            "A${System.lineSeparator()}", executor.runCommands(
                 listOf(
                     Echo(listOf("A")),
                     Grep(listOf("-i", "a"))
@@ -138,7 +138,7 @@ class ExecutorTest {
     @Test
     fun grepFindWord() {
         assertEquals(
-            "kek find me lol\n", executor.runCommands(
+            "kek find me lol${System.lineSeparator()}", executor.runCommands(
                 listOf(
                     Grep(listOf("-w", "find", getRealFileName("file4")))
                 )
@@ -149,7 +149,7 @@ class ExecutorTest {
     @Test
     fun grepMoreLines() {
         assertEquals(
-            "kek find me lol\nkeeeeek\n", executor.runCommands(
+            "kek find me lol${System.lineSeparator()}keeeeek${System.lineSeparator()}", executor.runCommands(
                 listOf(
                     Grep(listOf("-w", "-A", "1", "find", getRealFileName("file4")))
                 )

--- a/cli/src/test/kotlin/ru/iisuslik/cli/ExecutorTest.kt
+++ b/cli/src/test/kotlin/ru/iisuslik/cli/ExecutorTest.kt
@@ -36,32 +36,124 @@ class ExecutorTest {
 
     @Test
     fun catInput() {
-        assertEquals("kek", executor.runCommands(listOf(Echo(listOf("kek")),
-            Cat(emptyList()))))
+        assertEquals(
+            "kek", executor.runCommands(
+                listOf(
+                    Echo(listOf("kek")),
+                    Cat(emptyList())
+                )
+            )
+        )
     }
 
     @Test
     fun catInputIgnore() {
-        assertEquals("content1", executor.runCommands(listOf(Echo(listOf("kek")),
-            Cat(listOf(getRealFileName("file1"))))))
+        assertEquals(
+            "content1", executor.runCommands(
+                listOf(
+                    Echo(listOf("kek")),
+                    Cat(listOf(getRealFileName("file1")))
+                )
+            )
+        )
     }
 
     @Test
     fun wcSimple() {
-        assertEquals("${getRealFileName("file1")}: 1 1 8",
-            executor.runCommands(listOf(Wc(listOf(getRealFileName("file1"))))))
+        assertEquals(
+            "${getRealFileName("file1")}: 1 1 8",
+            executor.runCommands(listOf(Wc(listOf(getRealFileName("file1")))))
+        )
     }
 
     @Test
     fun wcInput() {
-        assertEquals("1 1 3", executor.runCommands(listOf(Echo(listOf("kek")),
-            Wc(emptyList()))))
+        assertEquals(
+            "1 1 3", executor.runCommands(
+                listOf(
+                    Echo(listOf("kek")),
+                    Wc(emptyList())
+                )
+            )
+        )
     }
 
     @Test
     fun wcInputIgnore() {
-        assertEquals("${getRealFileName("file1")}: 1 1 8",
-            executor.runCommands(listOf(Echo(listOf("kek")),
-            Wc(listOf(getRealFileName("file1"))))))
+        assertEquals(
+            "${getRealFileName("file1")}: 1 1 8",
+            executor.runCommands(
+                listOf(
+                    Echo(listOf("kek")),
+                    Wc(listOf(getRealFileName("file1")))
+                )
+            )
+        )
+    }
+
+    @Test
+    fun grepSimple() {
+        assertEquals(
+            "2\n",
+            executor.runCommands(listOf(Grep(listOf("2", getRealFileName("file4")))))
+        )
+    }
+
+    @Test
+    fun grepInput() {
+        assertEquals(
+            "1\n", executor.runCommands(
+                listOf(
+                    Echo(listOf("1")),
+                    Grep(listOf("1"))
+                )
+            )
+        )
+    }
+
+    @Test
+    fun grepInputIgnore() {
+        assertEquals(
+            "2\n", executor.runCommands(
+                listOf(
+                    Echo(listOf("1")),
+                    Grep(listOf("2", getRealFileName("file4")))
+                )
+            )
+        )
+    }
+
+    @Test
+    fun grepIgnoreCase() {
+        assertEquals(
+            "A\n", executor.runCommands(
+                listOf(
+                    Echo(listOf("A")),
+                    Grep(listOf("-i", "a"))
+                )
+            )
+        )
+    }
+
+    @Test
+    fun grepFindWord() {
+        assertEquals(
+            "kek find me lol\n", executor.runCommands(
+                listOf(
+                    Grep(listOf("-w", "find", getRealFileName("file4")))
+                )
+            )
+        )
+    }
+
+    @Test
+    fun grepMoreLines() {
+        assertEquals(
+            "kek find me lol\nkeeeeek\n", executor.runCommands(
+                listOf(
+                    Grep(listOf("-w", "-n", "1", "find", getRealFileName("file4")))
+                )
+            )
+        )
     }
 }

--- a/cli/src/test/kotlin/ru/iisuslik/cli/FileControllerTest.kt
+++ b/cli/src/test/kotlin/ru/iisuslik/cli/FileControllerTest.kt
@@ -47,7 +47,7 @@ class FileControllerTest {
     @Test
     fun grepFile() {
         assertEquals(
-            "kek find me lol\n",
+            "kek find me lol${System.lineSeparator()}",
             grepFiles(listOf(getRealFileName("file4")), "find me".toRegex(), 0)
         )
     }
@@ -55,7 +55,7 @@ class FileControllerTest {
     @Test
     fun grepFileIgnoringCase() {
         assertEquals(
-            "kek find me lol\n",
+            "kek find me lol${System.lineSeparator()}",
             grepFiles(listOf(getRealFileName("file4")), "FIND ME".toRegex(RegexOption.IGNORE_CASE), 0)
         )
     }
@@ -63,7 +63,7 @@ class FileControllerTest {
     @Test
     fun grepTwoFiles() {
         assertEquals(
-            "content1\ncontent2\n",
+            "content1${System.lineSeparator()}content2${System.lineSeparator()}",
             grepFiles(
                 listOf(getRealFileName("file1"), getRealFileName("file2")),
                 "content".toRegex(), 0
@@ -74,7 +74,8 @@ class FileControllerTest {
     @Test
     fun grepTwoLines() {
         assertEquals(
-            "kek find me lol\nlollollol\n",
+            "kek find me lol${System.lineSeparator()}" +
+                    "lollollol${System.lineSeparator()}",
             grepFiles(
                 listOf( getRealFileName("file4")),
                 "(lol)+".toRegex(), 0
@@ -85,7 +86,9 @@ class FileControllerTest {
     @Test
     fun grepAdditionalLines() {
         assertEquals(
-            "kek find me lol\nkeeeeek\nlollollol\n",
+            "kek find me lol${System.lineSeparator()}" +
+                    "keeeeek${System.lineSeparator()}" +
+                    "lollollol${System.lineSeparator()}",
             grepFiles(listOf(getRealFileName("file4")), "find me".toRegex(), 2)
         )
     }
@@ -93,14 +96,14 @@ class FileControllerTest {
     @Test
     fun grepWord() {
         assertEquals(
-            "kek find me lol\n",
+            "kek find me lol${System.lineSeparator()}",
             grepFiles(listOf(getRealFileName("file4")), "(\\b|^)find(\\b|$)".toRegex(), 0)
         )
     }
     @Test
     fun grepWordOneOnLine() {
         assertEquals(
-            "1\n",
+            "1${System.lineSeparator()}",
             grepFiles(listOf(getRealFileName("file4")), "(\\b|^)1(\\b|$)".toRegex(), 0)
         )
     }

--- a/cli/src/test/kotlin/ru/iisuslik/cli/FileControllerTest.kt
+++ b/cli/src/test/kotlin/ru/iisuslik/cli/FileControllerTest.kt
@@ -43,4 +43,65 @@ class FileControllerTest {
             wcFiles(listOf(getRealFileName("file3"), getRealFileName("file1")))
         )
     }
+
+    @Test
+    fun grepFile() {
+        assertEquals(
+            "kek find me lol\n",
+            grepFiles(listOf(getRealFileName("file4")), "find me".toRegex(), 0)
+        )
+    }
+
+    @Test
+    fun grepFileIgnoringCase() {
+        assertEquals(
+            "kek find me lol\n",
+            grepFiles(listOf(getRealFileName("file4")), "FIND ME".toRegex(RegexOption.IGNORE_CASE), 0)
+        )
+    }
+
+    @Test
+    fun grepTwoFiles() {
+        assertEquals(
+            "content1\ncontent2\n",
+            grepFiles(
+                listOf(getRealFileName("file1"), getRealFileName("file2")),
+                "content".toRegex(), 0
+            )
+        )
+    }
+
+    @Test
+    fun grepTwoLines() {
+        assertEquals(
+            "kek find me lol\nlollollol\n",
+            grepFiles(
+                listOf( getRealFileName("file4")),
+                "(lol)+".toRegex(), 0
+            )
+        )
+    }
+
+    @Test
+    fun grepAdditionalLines() {
+        assertEquals(
+            "kek find me lol\nkeeeeek\nlollollol\n",
+            grepFiles(listOf(getRealFileName("file4")), "find me".toRegex(), 2)
+        )
+    }
+
+    @Test
+    fun grepWord() {
+        assertEquals(
+            "kek find me lol\n",
+            grepFiles(listOf(getRealFileName("file4")), "(\\b|^)find(\\b|$)".toRegex(), 0)
+        )
+    }
+    @Test
+    fun grepWordOneOnLine() {
+        assertEquals(
+            "1\n",
+            grepFiles(listOf(getRealFileName("file4")), "(\\b|^)1(\\b|$)".toRegex(), 0)
+        )
+    }
 }

--- a/cli/src/test/kotlin/ru/iisuslik/cli/StatementParserTest.kt
+++ b/cli/src/test/kotlin/ru/iisuslik/cli/StatementParserTest.kt
@@ -35,6 +35,11 @@ class StatementParserTest {
     }
 
     @Test
+    fun parseGrep() {
+        assertEquals(getStatement(Grep(listOf("kek", "lol"))), parser.parse("grep kek lol"))
+    }
+
+    @Test
     fun parsePwd() {
         assertEquals(getStatement(Pwd), parser.parse("pwd"))
     }

--- a/cli/src/test/resources/file4
+++ b/cli/src/test/resources/file4
@@ -1,0 +1,7 @@
+kek find me lol
+keeeeek
+lollollol
+1
+2
+3
+1find1


### PR DESCRIPTION
После запроса гуглу `kotlin args parser` я получил несколько вариантов,
 но сразу выбрал первый - `kotlin-argparser`, так как я им уже пользовался и знаю как с ним работать. Никаких проблем по ходу дела не возникло, поэтому менять библиотеку не понадобилось.